### PR TITLE
Implement continuous note playback with motion-triggered drums and FX

### DIFF
--- a/addingNotes.py
+++ b/addingNotes.py
@@ -3,6 +3,7 @@ from pythonosc import osc_server
 import pygame
 import statistics
 from collections import deque
+import time
 
 # 🔊 Initialize pygame
 pygame.mixer.init()
@@ -18,7 +19,7 @@ notes = {
     'B': pygame.mixer.Sound("note_b.wav"),
 }
 
-# 🎶 Effects
+# 🎶 Load effects
 fx = {
     'drum': pygame.mixer.Sound("drum.wav"),
     'effect': pygame.mixer.Sound("effect.wav"),
@@ -29,61 +30,69 @@ fx = {
 channel_notes = pygame.mixer.Channel(0)
 channel_fx = pygame.mixer.Channel(1)
 
-# State
+# State variables
 last_note = None
 ambient_triggered = False
 mode = "notes"
+last_drum_time = 0  # Cooldown for drums
 
-# Smooth values (rolling average)
+# Rolling average for smooth accelerometer
 window_size = 5
 x_vals, y_vals, z_vals = deque(maxlen=window_size), deque(maxlen=window_size), deque(maxlen=window_size)
 
 def accel_handler(address, x, y, z):
-    global last_note, ambient_triggered, mode
+    global last_note, ambient_triggered, mode, last_drum_time
 
-    # Add new values for smoothing
-    x_vals.append(x); y_vals.append(y); z_vals.append(z)
+    # Append new values
+    x_vals.append(x)
+    y_vals.append(y)
+    z_vals.append(z)
 
-    # Use average to reduce jitter
+    # Smoothed values
     x = statistics.mean(x_vals)
     y = statistics.mean(y_vals)
     z = statistics.mean(z_vals)
 
+    now = time.time()
     print(f"Accel: x={x:.2f}, y={y:.2f}, z={z:.2f}, mode={mode}")
 
-    # 🎼 Notes mode (immediate)
+    # -----------------
+    # Notes mode
+    # -----------------
     if mode == "notes":
-        if x < -0.714:
-            note = 'C'
-        elif x < -0.429:
-            note = 'D'
-        elif x < -0.143:
-            note = 'E'
-        elif x < 0.143:
-            note = 'F'
-        elif x < 0.429:
-            note = 'G'
-        elif x < 0.714:
-            note = 'A'
-        else:
-            note = 'B'
+        # Map X-axis to 7 notes (equal slices)
+        if x < -0.714: note = 'C'
+        elif x < -0.429: note = 'D'
+        elif x < -0.143: note = 'E'
+        elif x < 0.143:  note = 'F'
+        elif x < 0.429:  note = 'G'
+        elif x < 0.714:  note = 'A'
+        else: note = 'B'
 
-        # Play only if note changed
+        # Continuous note playback
         if note != last_note:
-            print(f"🎵 Playing {note}")
-            channel_notes.play(notes[note])
+            if last_note is not None:
+                channel_notes.stop()  # Stop previous note
+            channel_notes.play(notes[note], loops=-1)  # Play current note indefinitely
             last_note = note
+            print(f"🎵 Playing {note}")
 
-        # Drum trigger (instant)
-        if abs(z) > 1.2:
+        # Drum trigger (Z-axis) with short cooldown
+        if abs(z) > 1.2 and now - last_drum_time > 0.2:
             print("🥁 Drum!")
             channel_fx.play(fx['drum'])
+            last_drum_time = now
 
-    # 🎧 FX mode (instant)
+    # -----------------
+    # FX mode
+    # -----------------
     if mode == "fx":
+        # Effect trigger
         if y > 0.6:
             print("🎧 FX!")
             channel_fx.play(fx['effect'])
+
+        # Ambient trigger
         elif y < -0.6 and not ambient_triggered:
             print("🌫 Ambient!")
             channel_fx.play(fx['ambient'])
@@ -91,8 +100,9 @@ def accel_handler(address, x, y, z):
         elif -0.6 <= y <= 0.6:
             ambient_triggered = False
 
-
-# 🧭 OSC setup
+# -----------------
+# OSC server setup
+# -----------------
 dispatcher = Dispatcher()
 dispatcher.map("/accel", accel_handler)
 


### PR DESCRIPTION
- Continuous notes: Only one note plays at a time until X-axis changes
- Drum (Z-axis) triggers with short 0.2s cooldown to prevent overlap
- FX (Y-axis) triggers instantly: effect for positive tilt, ambient for negative
- Smoothed accelerometer input using rolling average to reduce jitter
- OSC listener added for receiving motion data in real-time